### PR TITLE
Show async-trait doesn't work (at least out of the box)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +112,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 name = "hello-world"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "hyper",
  "tokio",
  "utils",
@@ -479,6 +491,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 [[package]]
 name = "utils"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+]
 
 [[package]]
 name = "want"

--- a/hello-world/BUILD.bazel
+++ b/hello-world/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@crates//:defs.bzl", "crates_from")
+load("@crates//:defs.bzl", "crates_from", "proc_macro_crates_from")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 rust_binary(
@@ -7,4 +7,5 @@ rust_binary(
 			"src/main.rs"
 		],
     deps = crates_from("//hello-world:Cargo.toml") + ["//utils"],
+    proc_macro_deps = proc_macro_crates_from("//hello-world:Cargo.toml"),
 )

--- a/hello-world/Cargo.toml
+++ b/hello-world/Cargo.toml
@@ -10,6 +10,7 @@ name = "hello_world"
 path = "src/main.rs"
 
 [dependencies]
+async-trait = "0.1.52"
 hyper = { version = "0.14.16", features = ["full"] }
 tokio = { version = "1.14.0", features = ["full"] }
 utils = { path = "../utils" }

--- a/hello-world/src/main.rs
+++ b/hello-world/src/main.rs
@@ -1,7 +1,19 @@
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server};
-use std::convert::Infallible;
-use std::net::SocketAddr;
+use async_trait::async_trait;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use std::{convert::Infallible, error::Error, net::SocketAddr};
+use utils::SomeAsyncTrait;
+
+struct SomeAsyncStruct;
+
+#[async_trait]
+impl SomeAsyncTrait for SomeAsyncStruct {
+    async fn do_async_stuff(&self) -> Result<String, Box<dyn Error>> {
+        Ok("stuff!".into())
+    }
+}
 
 async fn hello_world(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
     Ok(Response::new("Hello, World".into()))
@@ -10,6 +22,9 @@ async fn hello_world(_req: Request<Body>) -> Result<Response<Body>, Infallible> 
 #[tokio::main]
 async fn main() {
     println!("stuff = {}", utils::get_stuff());
+    let async_struct = SomeAsyncStruct;
+    let res = async_struct.do_async_stuff().await.unwrap();
+    println!("res = {}", res);
 
     // We'll bind to 127.0.0.1:3000
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/utils/BUILD.bazel
+++ b/utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@crates//:defs.bzl", "crates_from")
+load("@crates//:defs.bzl", "crates_from", "proc_macro_crates_from")
 
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
@@ -6,5 +6,6 @@ rust_library(
     name = "utils",
     srcs = glob(["src/**/*.rs"]),
     deps = crates_from("//utils:Cargo.toml"),
+    proc_macro_deps = proc_macro_crates_from("//utils:Cargo.toml"),
 		visibility = ["//visibility:public"],
 )

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.52"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,5 +1,14 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
 pub fn get_stuff() -> String {
     "stuff!".into()
+}
+
+#[async_trait]
+pub trait SomeAsyncTrait {
+    async fn do_async_stuff(&self) -> Result<String, Box<dyn Error>>;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fails to build for me:

```
bazel run //hello-world
INFO: Analyzed target //hello-world:hello-world (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /home/amos/work/crate-universe-sample/utils/BUILD.bazel:5:13: Compiling Rust rlib utils (1 files) failed: (Exit 1): process_wrapper failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' -- external/rust_linux_x86_64/bin/rustc utils/src/lib.rs '--crate-name=utils' ... (remaining 17 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
error[E0706]: functions in traits cannot be declared `async`
  --> utils/src/lib.rs:11:5
   |
11 |     async fn do_async_stuff(&self) -> Result<String, Box<dyn Error>>;
   |     -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     `async` because of this
   |
   = note: `async` trait functions are not currently supported
   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait

error[E0432]: unresolved import `async_trait`
 --> utils/src/lib.rs:3:5
  |
3 | use async_trait::async_trait;
  |     ^^^^^^^^^^^ use of undeclared crate or module `async_trait`

error: cannot determine resolution for the attribute macro `async_trait`
 --> utils/src/lib.rs:9:3
  |
9 | #[async_trait]
  |   ^^^^^^^^^^^
  |
  = note: import resolution is stuck, try simplifying macro imports

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0432, E0706.
For more information about an error, try `rustc --explain E0432`.
Target //hello-world:hello-world failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.155s, Critical Path: 0.04s
INFO: 7 processes: 7 internal.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```